### PR TITLE
Add additional install steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ Behind-the-scenes, this extension uses [PayPal's Merchant Ruby SDK](https://gith
 
 ## Installation
 
-Add this extension to your Gemfile with this line:
+1. Add this extension to your Gemfile with this line:
 
-    gem 'spree_paypal_express', :github => "radar/better_spree_paypal_express", :branch => "2-0-stable"
+        gem 'spree_paypal_express', :github => "radar/better_spree_paypal_express", :branch => "2-0-stable"
+
+2. Install the gem using Bundler:
+
+        bundle install
+
+3. Copy & run migrations
+
+        bundle exec rails g spree_paypal_express:install
 
 ### Sandbox Setup
 


### PR DESCRIPTION
@gerep in #spree noted that the migration installation was missing from the readme. Copied the instructions from the existing gem.
