### PR TITLE
Don't instantiate provider in provider_class

### DIFF
--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -6,8 +6,12 @@ module Spree
     preference :signature, :string
     preference :server, :string, default: 'sandbox'
 
+    def supports?(source)
+      true
+    end
+
     def provider_class
-      ::PayPal::SDK::Merchant::API.new
+      ::PayPal::SDK::Merchant::API
     end
 
     def provider
@@ -16,7 +20,7 @@ module Spree
         :username  => preferred_login,
         :password  => preferred_password,
         :signature => preferred_signature)
-      provider_class
+      provider_class.new
     end
 
     def auto_capture?


### PR DESCRIPTION
It was possible for payment_class to be called, which instantiated a new`PayPal::SDK::Merchant::API` object before paypal was configured by the code in .provider. This caused the error as seen in #15:

```
No such file or directory - config/paypal.yml
```

This changes provider_class to just return the class itself. It also overrides `.provides?` to be more explicit about the behaviour.
