### PR TITLE
Allow form submission to redirect to proper URL.

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,0 +1,29 @@
+module Spree
+  CheckoutController.class_eval do
+
+    before_filter :redirect_to_paypal_express_form_if_needed, :only => [:update]
+
+    def redirect_to_paypal_express_form_if_needed
+      return unless (params[:state] == "payment")
+      return unless params[:order][:payments_attributes]
+
+      payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
+      return unless payment_method.kind_of?(Spree::Gateway::PayPalExpress)# || payment_method.kind_of?(Spree::Gateway::PaypalExpressUk)
+
+      update_params = object_params.dup
+      update_params.delete(:payments_attributes)
+      if @order.update_attributes(update_params)
+        fire_event('spree.checkout.update')
+        render :edit and return unless apply_coupon_code
+      end
+
+      load_order
+      if not @order.errors.empty?
+         render :edit and return
+      end
+
+      redirect_to(paypal_express_url(:payment_method_id => payment_method.id)) and return
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.routes.append do
-  post '/paypal', :to => "paypal#express", :as => :paypal_express
+  match '/paypal', :to => "paypal#express", :as => :paypal_express, :via => [:get, :post]
   get '/paypal/confirm', :to => "paypal#confirm", :as => :confirm_paypal
   get '/paypal/cancel', :to => "paypal#cancel", :as => :cancel_paypal
   get '/paypal/notify', :to => "paypal#notify", :as => :notify_paypal


### PR DESCRIPTION
When checking out, the user must click on the paypal express icon in order to complete checkout. This is a bit odd for a site where that is the only checkout option since users can click "SAVE AND CONTINUE" which just brings them back to the same screen again.

Copied from the old spree_paypal_express so not sure how correct it is, just got it to work...

It was done rather quickly but seems to work. I don't have enough involvement with this project to say for sure this is what is correct to be done or not (maybe all thats needed is to redirect_to(payment_method_id: params[:payment_method_id] ??? )
