### PR TITLE
Update unit tests to be headless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 .#*
 .DS_Store
 coverage
+results.xml
 Gemfile.lock
 tmp
 pkg
 spec/dummy
 .rvmrc
+.idea

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,15 @@ gem 'spree', :github => 'spree/spree', :branch => '2-0-stable'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => '2-0-stable'
 gem 'sqlite3'
 gem 'pg'
+gem 'database_cleaner', '1.0.1'
+
+group :test do
+ gem 'simplecov'
+ gem 'simplecov-rcov'
+ gem 'yarjuf'
+ gem 'require_all'
+ gem 'capybara'
+ gem 'poltergeist'
+end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -6,18 +6,26 @@ require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 require 'spree/testing_support/extension_rake'
 
-RSpec::Core::RakeTask.new
-
-task default: :spec
-
-spec = eval(File.read('spree_paypal_express.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
-end
-
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'spree_paypal_express'
   Rake::Task['extension:test_app'].invoke
 end
+
+require 'rspec/core'
+require 'rspec/core/rake_task'
+Rake::Task["spec"].clear
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.fail_on_error = false
+  t.rspec_opts = %w[-f JUnit -o results.xml]
+end
+
+desc "Run RSpec with code coverage"
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task["spec"].execute
+end
+task :default => :spec
+
+
+Bundler::GemHelper.install_tasks

--- a/spec/models/pay_pal_express_spec.rb
+++ b/spec/models/pay_pal_express_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Gateway::PayPalExpress do
   context "payment purchase" do
     let(:payment) do
       payment = FactoryGirl.create(:payment, :payment_method => gateway, :amount => 10)
-      payment.stub :source => mock_model(Spree::PaypalExpressCheckout, :token => 'fake_token', :payer_id => 'fake_payer_id')
+      payment.stub :source => mock_model(Spree::PaypalExpressCheckout, :token => 'fake_token', :payer_id => 'fake_payer_id', :update_column => true)
       payment
     end
 
@@ -32,10 +32,10 @@ describe Spree::Gateway::PayPalExpress do
           ]
         }
       })
-      response = double('pp_response', :success? => true) 
+      response = double('pp_response', :success? => true)
+      response.stub_chain("do_express_checkout_payment_response_details.payment_info.first.transaction_id").and_return '12345'
       provider.should_receive(:do_express_checkout_payment).and_return(response)
-      payment.purchase!
-      # lambda { payment.purchase! }.should_not raise_error
+      lambda { payment.purchase! }.should_not raise_error
     end
 
     # Test for #4

--- a/spec/rcov_exclude_list.rb
+++ b/spec/rcov_exclude_list.rb
@@ -1,0 +1,4 @@
+@exclude_list = [
+  'db/**/*.rb',
+  'spec/**/*.rb'
+]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,16 @@
+if ENV["COVERAGE"]
+  require_relative 'rcov_exclude_list.rb'
+  exlist = Dir.glob(@exclude_list)
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start do
+    exlist.each do |p|
+      add_filter p
+    end
+  end
+end
+
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
@@ -6,8 +19,13 @@ require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
-require 'capybara/rspec'
 require 'pry'
+require 'capybara/rspec'
+require 'capybara/rails'
+require 'capybara/poltergeist'
+ 
+Capybara.javascript_driver = :poltergeist
+Capybara.default_wait_time = 15
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
@@ -42,4 +60,9 @@ RSpec.configure do |config|
   end
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+end
+
+if ENV["COVERAGE"]
+  # Load all files except the ones in exclude list
+  require_all(Dir.glob('**/*.rb') - exlist)
 end


### PR DESCRIPTION
Setup RSpec tests to run on phantomJS, which allows the tests to be run on a CI server, where there is likely no firefox installation available.
Also setup project to support simplecov for test coverage measurement (use "rake coverage")
