### PR TITLE
spree_core version fixed in order to make it work with Spree 2.1.0 relea...

### DIFF
--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
 
-  s.add_dependency 'spree_core', '~> 2.1.1'
+  s.add_dependency 'spree_core', '~> 2.1.0'
   s.add_dependency 'paypal-sdk-merchant', '1.103.0'
 
   s.add_development_dependency 'capybara', '~> 2.1'


### PR DESCRIPTION
What about if I want to use this gem with the Spree 2.0.1 release ?
I had to do this to make it works.
