### PR TITLE
Added ecommerce flash

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -72,6 +72,7 @@ module Spree
       order.next
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
+        flash[:commerce_tracking] = "nothing special"
         redirect_to order_path(order, :token => order.token)
       else
         redirect_to checkout_state_path(order.state)


### PR DESCRIPTION
Currently Paypal transactions aren't being tracked in Google Analytics. This adds the flash that triggers the ecommerce section of the `_google_analytics.html.erb` to be displayed.
