### PR TITLE
Confirm orders, credit orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ The PayPal Express Checkout has [no less than 4.5 billion configuration options]
 
 This Spree extension supports *some* of those. If your favourite is not here, then please submit an issue about it, or better still a patch to add it in.
 
-### Solution Type
+### Solution
 
 Determines whether or not a user needs a PayPal account to check out. 
 
 ```ruby
-payment_method.preferred_solution_type = "Mark"
+payment_method.preferred_solution = "Mark"
 # or
-payment_method.preferred_solution_type = "Sole"
+payment_method.preferred_solution = "Sole"
 ```
 
 "Mark" if you do want users to have a paypal account, "Sole" otherwise. 
@@ -65,9 +65,9 @@ payment_method.preferred_solution_type = "Sole"
 Determines which page to show users once they're redirected to PayPal.
 
 ```ruby
-payment_method.preferred_solution_type = "Login"
+payment_method.preferred_landing_page = "Login"
 # or
-payment_method.preferred_solution_type = "Billing"
+payment_method.preferred_landing_page = "Billing"
 ```
 
 "Login" will show the users the login form for PayPal, and "Billing" will show them a form where they can enter their credit card data and possibly sign up for a PayPal account (depending on the Solution Type setting above).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You will also need a "Personal" account to test the transactions on your site. C
 
 #### Spree Setup
 
-In Spree, go to the admin backend, click "Configuration" and then "Payment Methods" and create a new payment method. Select "Spree::Gateway::PayPalExpress" as the provider, and click "Create". Enter the email address, password and signature from the "API Credentials" tab for the **Business** account on PayPal. 
+In Spree, go to the admin backend, click "Configuration" and then "Payment Methods" and create a new payment method. Select "Spree::Gateway::PayPalExpress" as the provider, and click "Create". Enter the email address, password and signature from the "API Credentials" tab for the **Business** account on PayPal.
 
 ### Production setup
 
@@ -48,9 +48,20 @@ The PayPal Express Checkout has [no less than 4.5 billion configuration options]
 
 This Spree extension supports *some* of those. If your favourite is not here, then please submit an issue about it, or better still a patch to add it in.
 
+
+### Checkout confirmation step
+
+Determines whether or not checkout should have a final confirmation step.
+
+```ruby
+payment_method.preferred_review = true #after paypal payment, user will be redirected on spree, it will show a final confirmation step.
+# or
+payment_method.preferred_review = false
+```
+
 ### Solution
 
-Determines whether or not a user needs a PayPal account to check out. 
+Determines whether or not a user needs a PayPal account to check out.
 
 ```ruby
 payment_method.preferred_solution = "Mark"
@@ -58,7 +69,7 @@ payment_method.preferred_solution = "Mark"
 payment_method.preferred_solution = "Sole"
 ```
 
-"Mark" if you do want users to have a paypal account, "Sole" otherwise. 
+"Mark" if you do want users to have a paypal account, "Sole" otherwise.
 
 ### Landing Page
 

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -49,7 +49,7 @@ module Spree
       begin
         pp_response = provider.set_express_checkout(pp_request)
         if pp_response.success?
-          redirect_to provider.express_checkout_url(pp_response)
+          redirect_to provider.express_checkout_url(pp_response, express_checkout_options)
         else
           flash[:error] = "PayPal failed. #{pp_response.errors.map(&:long_message).join(" ")}"
           redirect_to checkout_state_path(:payment)
@@ -143,6 +143,12 @@ module Spree
         :Country => current_order.bill_address.country.iso,
         :PostalCode => current_order.bill_address.zipcode
       }
+    end
+
+    def express_checkout_options
+      {}.tap do |opts|
+        opts[:useraction] = 'commit' if current_order.confirmation_required?
+      end
     end
   end
 end

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -147,7 +147,7 @@ module Spree
 
     def express_checkout_options
       {}.tap do |opts|
-        opts[:useraction] = 'commit' if current_order.confirmation_required?
+        opts[:useraction] = 'commit' if !current_order.confirmation_required?
       end
     end
   end

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -8,9 +8,10 @@ module Spree
     preference :solution, :string, default: 'Mark'
     preference :landing_page, :string, default: 'Billing'
     preference :logourl, :string, default: ''
+    preference :review, :boolean, default: false
 
     attr_accessible :preferred_login, :preferred_password, :preferred_signature,
-                    :preferred_solution, :preferred_logourl, :preferred_landing_page
+                    :preferred_solution, :preferred_logourl, :preferred_landing_page, :preferred_review
 
     def supports?(source)
       true
@@ -71,6 +72,10 @@ module Spree
         end
         pp_response
       end
+    end
+
+    def payment_profiles_supported?
+      preferred_review
     end
 
     def refund(payment, amount)

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -99,7 +99,7 @@ module Spree
     end
 
     def credit(amount, source, response_code={}, options={})
-      amount /= 100 #was in cents
+      amount /= 100.to_f #was in cents
 
       total = (options[:shipping] + options[:tax] + options[:subtotal] + options[:discount]) / 100
       refund_type = total == amount ? 'Full' : 'Partial'

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -48,20 +48,7 @@ module Spree
           :PaymentAction => "Sale",
           :Token => express_checkout.token,
           :PayerID => express_checkout.payer_id,
-          :PaymentDetails => [{
-            :OrderTotal => {
-              :currencyID => Spree::Config[:currency],
-              # gsub is here because PayPal fails to acknowledge
-              # that some people like their currencies written as:
-              # 21,99
-              # As opposed to:
-              # 21.99
-              # The international payments company fails to handle
-              # international payment amounts. SMH.
-              :value => ::Money.new(amount, Spree::Config[:currency]).to_s.gsub(',', '.')
-            },
-            :PaymentDetailsItem => pp_details_response.get_express_checkout_details_response_details.PaymentDetails[0].PaymentDetailsItem
-          }]
+          :PaymentDetails => pp_details_response.get_express_checkout_details_response_details.PaymentDetails
         }
       })
 

--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -71,7 +71,10 @@ module Spree
     end
 
     def payment_profiles_supported?
-      preferred_review
+      !!preferred_review
+    end
+
+    def create_profile(payment)
     end
 
     def refund(payment, amount)

--- a/app/models/spree/paypal_express_checkout.rb
+++ b/app/models/spree/paypal_express_checkout.rb
@@ -8,8 +8,8 @@ module Spree
     end
 
     def can_credit?(payment)
-      return false unless payment.state == "completed"
-      return false unless payment.order.payment_state == "credit_owed"
+      return false unless payment.completed?
+      return false unless payment.order.outstanding_balance?
       return false unless payment.payment_method.payment_profiles_supported?
       payment.credit_allowed > 0
     end

--- a/app/models/spree/paypal_express_checkout.rb
+++ b/app/models/spree/paypal_express_checkout.rb
@@ -1,4 +1,18 @@
 module Spree
   class PaypalExpressCheckout < ActiveRecord::Base
+
+    # add payment actions here...
+    # %w{capture credit}
+    def actions
+      %w{credit}
+    end
+
+    def can_credit?(payment)
+      return false unless payment.state == "completed"
+      return false unless payment.order.payment_state == "credit_owed"
+      return false unless payment.payment_method.payment_profiles_supported?
+      payment.credit_allowed > 0
+    end
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Spree::Core::Engine.routes.append do
   post '/paypal', :to => "paypal#express", :as => :paypal_express
+  put '/paypal', :to => "paypal#express", :as => :paypal_express
   get '/paypal/confirm', :to => "paypal#confirm", :as => :confirm_paypal
   get '/paypal/cancel', :to => "paypal#cancel", :as => :cancel_paypal
   get '/paypal/notify', :to => "paypal#notify", :as => :notify_paypal

--- a/spec/features/paypal_spec.rb
+++ b/spec/features/paypal_spec.rb
@@ -274,14 +274,14 @@ describe "PayPal", :js => true do
       it 'can automatically credit payment when payment_profiles is supported' do
         # create 1st adjustment
         click_link "New Adjustment"
-        fill_in "adjustment_amount", :with => "-10"
+        fill_in "adjustment_amount", :with => "-10.90"
         fill_in "adjustment_label", :with => "rebate"
         click_button "Continue"
         page.should have_content("successfully created!")
 
         # can credit first time
         visit spree.admin_order_payments_path(Spree::Order.last.number)
-        page.should have_content('CREDIT OWED: -$10.00')
+        page.should have_content('CREDIT OWED: -$10.90')
         click_icon :credit
         page.should have_content 'Payment Updated'
 

--- a/spec/features/paypal_spec.rb
+++ b/spec/features/paypal_spec.rb
@@ -3,10 +3,12 @@ require 'spec_helper'
 describe "PayPal", :js => true do
   let!(:product) { FactoryGirl.create(:product, :name => 'iPad') }
   before do
+    Spree::Config[:always_include_confirm_step] = false
     @gateway = Spree::Gateway::PayPalExpress.create!({
       :preferred_login => "pp_api1.ryanbigg.com",
       :preferred_password => "1383066713",
       :preferred_signature => "An5ns1Kso7MWUdW4ErQKJJJ4qi4-Ar-LpzhMJL0cu8TjM8Z2e1ykVg5B",
+      :preferred_review => false,
       :name => "PayPal",
       :active => true,
       :environment => Rails.env

--- a/spec/features/paypal_spec.rb
+++ b/spec/features/paypal_spec.rb
@@ -239,6 +239,67 @@ describe "PayPal", :js => true do
         click_button "Refund"
         page.should have_content("PayPal refund unsuccessful (The partial refund amount is not valid)")
       end
+
+    end
+
+    context 'credit payment with review' do
+      before do
+        @gateway.update_attributes preferred_review: true
+        visit spree.root_path
+        click_link 'iPad'
+        click_button 'Add To Cart'
+        click_button 'Checkout'
+        within("#guest_checkout") do
+          fill_in "Email", :with => "test@example.com"
+          click_button 'Continue'
+        end
+        fill_in_billing
+        click_button "Save and Continue"
+        # Delivery step doesn't require any action
+        click_button "Save and Continue"
+        find("#paypal_button").click
+        switch_to_paypal_login
+        fill_in "login_email", :with => "pp@spreecommerce.com"
+        fill_in "login_password", :with => "thequickbrownfox"
+        click_button "Log In"
+        find("#continue_abovefold").click   # Because there's TWO continue buttons.
+        click_button 'Place Order'
+        page.should have_content("Your order has been processed successfully")
+
+        visit spree.admin_order_adjustments_path(Spree::Order.last.number)
+      end
+
+      it 'can automatically credit payment when payment_profiles is supported' do
+        # create 1st adjustment
+        click_link "New Adjustment"
+        fill_in "adjustment_amount", :with => "-10"
+        fill_in "adjustment_label", :with => "rebate"
+        click_button "Continue"
+        page.should have_content("successfully created!")
+
+        # can credit first time
+        visit spree.admin_order_payments_path(Spree::Order.last.number)
+        page.should have_content('CREDIT OWED: -$10.00')
+        click_icon :credit
+        page.should have_content 'Payment Updated'
+
+
+        visit spree.admin_order_adjustments_path(Spree::Order.last.number)
+        # create 2nd adjustment
+        click_link "New Adjustment"
+        fill_in "adjustment_amount", :with => "-5"
+        fill_in "adjustment_label", :with => "rebate"
+        click_button "Continue"
+        page.should have_content("successfully created!")
+
+        # can credit 2nd time
+        visit spree.admin_order_payments_path(Spree::Order.last.number)
+        page.should have_content('CREDIT OWED: -$5.00')
+        click_icon :credit
+        page.should have_content 'Payment Updated'
+
+      end
+
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,9 @@ require 'ffaker'
 require 'pry'
 require 'capybara/rspec'
 require 'capybara/rails'
-# require 'capybara/poltergeist'
-require 'debugger'
+require 'capybara/poltergeist'
 
-# Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :poltergeist
 Capybara.default_wait_time = 15
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,14 +22,16 @@ require 'ffaker'
 require 'pry'
 require 'capybara/rspec'
 require 'capybara/rails'
-require 'capybara/poltergeist'
- 
-Capybara.javascript_driver = :poltergeist
+# require 'capybara/poltergeist'
+require 'debugger'
+
+# Capybara.javascript_driver = :poltergeist
 Capybara.default_wait_time = 15
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
 require 'spree/testing_support/factories'
+require 'spree/testing_support/capybara_ext'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/url_helpers'

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -26,8 +26,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
 
   s.add_development_dependency 'capybara', '~> 2.1'
+  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
+  s.add_development_dependency 'debugger'
   s.add_development_dependency 'factory_girl', '~> 4.2'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.13'

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -26,10 +26,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
 
   s.add_development_dependency 'capybara', '~> 2.1'
-  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'debugger'
   s.add_development_dependency 'factory_girl', '~> 4.2'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.13'


### PR DESCRIPTION
Hi,

This PR adds 2 main feature missing from original spree_paypal_express :

- credit orders using spree flow:
![screen shot 2013-11-20 at 9 13 48 pm](https://f.cloud.github.com/assets/159814/1585799/5f87af80-5220-11e3-99ea-dbd5ef98a793.jpg)
payment method should have 'review' preference to true

- confirm orders: https://github.com/radar/better_spree_paypal_express/issues/34
if payment method review preference is true, we should be able to confirm orders on spree.
it worked for 'Billing' landing page (credit card), not sure it did not work for 'Login' (paypal).

Specs are now green btw, should consider adding travis :beer: !