### PR TITLE
Customer confirms the payment inside paypal.

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -51,7 +51,7 @@ module Spree
       begin
         pp_response = provider.set_express_checkout(pp_request)
         if pp_response.success?
-          redirect_to provider.express_checkout_url(pp_response)
+          redirect_to provider.express_checkout_url(pp_response, :useraction => 'commit')
         else
           flash[:error] = "PayPal failed. #{pp_response.errors.map(&:long_message).join(" ")}"
           redirect_to checkout_state_path(:payment)


### PR DESCRIPTION
according to the [paypal doc page](https://developer.paypal.com/webapps/developer/docs/classic/express-checkout/integration-guide/ECCustomizing/)
" If you collect no additional information after buyers return from PayPal, you can skip the confirm-order page on your website. " , which is the case for spree. so they can finish the payment
in paypal, cuz we already gathered all the required information.

[Fixes #34]
