### PR TITLE
Switch .attr() to .prop() for disabling form els

### DIFF
--- a/app/assets/javascripts/admin/spree_paypal_express.js
+++ b/app/assets/javascripts/admin/spree_paypal_express.js
@@ -4,13 +4,13 @@ SpreePaypalExpress = {
   hideSettings: function(paymentMethod) {
     if (SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID) {
       $('.payment-method-settings').children().hide();
-      $('#payment_amount').attr('disabled', 'disabled');
-      $('button[type="submit"]').attr('disabled', 'disabled');
+      $('#payment_amount').prop('disabled', 'disabled');
+      $('button[type="submit"]').prop('disabled', 'disabled');
       $('#paypal-warning').show();
     } else if (SpreePaypalExpress.paymentMethodID) {
       $('.payment-method-settings').children().show();
-      $('button[type=submit]').attr('disabled', '');
-      $('#payment_amount').attr('disabled', '')
+      $('button[type=submit]').prop('disabled', '');
+      $('#payment_amount').prop('disabled', '')
       $('#paypal-warning').hide();
     }
   }


### PR DESCRIPTION
Replacing calls to `.attr('disabled', '')` with `.prop('disabled', '')` fixes #54 on `2-0-stable`.

From the [jQuery docs](http://api.jquery.com/attr/) on `.attr()`:

> As of jQuery 1.6, the .attr() method returns undefined for attributes that have not been set. To retrieve and change DOM properties such as the checked, selected, or disabled state of form elements, use the .prop() method.

I'm no jQuery expert, but it seems to have fixed my problem locally.  Here's a gist of my full deface override: https://gist.github.com/dpritchett/7256ea124f0aa6e272fb
