### PR TITLE
Add comment lines to fix assets:precompile.

### DIFF
--- a/app/assets/stylesheets/admin/spree_paypal_express.css
+++ b/app/assets/stylesheets/admin/spree_paypal_express.css
@@ -1,4 +1,4 @@
 /*
-*= require store/spree_core
-*= require store/spree_promo
+*= require admin/spree_core
+*= require admin/spree_promo
 */


### PR DESCRIPTION
bundle exec rake assets:precompile would fail with the following error message:

rake aborted!
Invalid CSS after "*": expected "{", was "= require store..."
