### PR TITLE
Pass cancel token back to checkout

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -84,7 +84,7 @@ module Spree
     def cancel
       flash[:notice] = "Don't want to use PayPal? No problems."
       order = current_order || raise(ActiveRecord::RecordNotFound)
-      redirect_to checkout_state_path(order.state)
+      redirect_to checkout_state_path(order.state, paypal_cancel_token: params["token"])
     end
 
     private


### PR DESCRIPTION
Reasoning: as it is we lose the information that an order has been canceled. Better to keep it around so programmers can customise post Paypal failure cancellation experience.
