### PR TITLE
clear order_id session (mirror CheckoutController)

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -75,6 +75,7 @@ module Spree
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
         flash[:commerce_tracking] = "nothing special"
+        session[:order_id] = nil
         redirect_to order_path(order, :token => order.token)
       else
         redirect_to checkout_state_path(order.state)


### PR DESCRIPTION
I noticed a lack of symmetry between the "success" part of the update method in Spree::CheckoutController and here, whereby the order_id is cleared in one but not the other.
https://github.com/spree/spree/pull/2557

More generally the problem is that we have duplication of the success code within Paypal Express and within Spree Core code. This has caused problems in the past (issue 41, I believe). A possible refactor would be to slap the four lines of completion code (e.g. setting the flash ecommerce) into a Spree Core module (exiting or new) that gets pulled into this and checkout controller.
