### PR TITLE
don't error out, if address page was missing due to customized checkout flow

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -150,7 +150,7 @@ module Spree
     end
 
     def address_required?
-      !payment_method.preferred_solution.eql?('Mark')
+      payment_method.preferred_solution.eql?('Sole')
     end
   end
 end


### PR DESCRIPTION
In case of customized checkout flow, if address page was missing - error will show. But not anymore.
