### PR TITLE
Support Spree 2.2.2

### DIFF
--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.0.beta'
+  s.add_dependency 'spree_core', '~> 2.2.0'
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
 
   s.add_development_dependency 'capybara', '~> 2.1'


### PR DESCRIPTION
This extension had conflicts with me upgrading to Spree 2.2.2 as it was looking for 2.2.1. Changing this line fixed it.

<pre>
<code>spree_paypal_express (>= 0) ruby depends on
       spree_core (2.2.1)
</code></pre>
