### PR TITLE
Fix "Save & Continue" + Payment Profiles.

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/frontend/spree_paypal_express.js
@@ -1,21 +1,31 @@
 //= require spree/frontend
 
 SpreePaypalExpress = {
-  hidePaymentSaveAndContinueButton: function(paymentMethod) {
-    if (!$('#use_existing_card_yes:checked').length && SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID) {
-      $('.continue').hide();
+  updateSaveAndContinueVisibility: function() {
+    if (this.isButtonHidden()) {
+      $(this).trigger('hideSaveAndContinue')
     } else {
-      $('.continue').show();
+      $(this).trigger('showSaveAndContinue')
     }
+  },
+  isButtonHidden: function () {
+    paymentMethod = this.checkedPaymentMethod();
+    return (!$('#use_existing_card_yes:checked').length && SpreePaypalExpress.paymentMethodID && paymentMethod.val() == SpreePaypalExpress.paymentMethodID);
   },
   checkedPaymentMethod: function() {
     return $('div[data-hook="checkout_payment_step"] input[type="radio"][name="order[payments_attributes][][payment_method_id]"]:checked');
+  },
+  hideSaveAndContinue: function() {
+    $('.continue').hide();
+  },
+  showSaveAndContinue: function() {
+    $('.continue').show();
   }
 }
 
 $(document).ready(function() {
-  SpreePaypalExpress.hidePaymentSaveAndContinueButton(SpreePaypalExpress.checkedPaymentMethod());
+  SpreePaypalExpress.updateSaveAndContinueVisibility();
   paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
-    SpreePaypalExpress.hidePaymentSaveAndContinueButton(SpreePaypalExpress.checkedPaymentMethod());
+    SpreePaypalExpress.updateSaveAndContinueVisibility();
   });
 })


### PR DESCRIPTION
Previously, the save & continue button would not be removed when combined with
certain payment profile options.
