### PR TITLE
Add ssl_allowed to PaypalController

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -1,5 +1,7 @@
 module Spree
   class PaypalController < StoreController
+    ssl_allowed
+
     def express
       order = current_order || raise(ActiveRecord::RecordNotFound)
       items = order.line_items.map(&method(:line_item))


### PR DESCRIPTION
Previously, when `redirect_https_to_http` was enabled, this would redirect (or issue 426) when requested with SSL. Obviously SSL should be allowed (if not enforced).

Fixes #105
