### PR TITLE
Don't ask for shipping information

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -92,6 +92,7 @@ module Spree
           :SolutionType => payment_method.preferred_solution.present? ? payment_method.preferred_solution : "Mark",
           :LandingPage => payment_method.preferred_landing_page.present? ? payment_method.preferred_landing_page : "Billing",
           :cppheaderimage => payment_method.preferred_logourl.present? ? payment_method.preferred_logourl : "",
+          :NoShipping => 1,
           :PaymentDetails => [payment_details(items)]
       }}
     end


### PR DESCRIPTION
Spree gathers shipping in the address step, so it is unnecessary to request
this from paypal. This removes the prompt for a shipping address in the paypal
interface, which should be a better customer experience.

Related to #103.
