### PR TITLE
Pass customer email and phone number to PayPal

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -89,6 +89,7 @@ module Spree
     def express_checkout_request_details order, items
       { :SetExpressCheckoutRequestDetails => {
           :InvoiceID => order.number,
+          :BuyerEmail => order.email,
           :ReturnURL => confirm_paypal_url(:payment_method_id => params[:payment_method_id], :utm_nooverride => 1),
           :CancelURL =>  cancel_paypal_url,
           :SolutionType => payment_method.preferred_solution.present? ? payment_method.preferred_solution : "Mark",
@@ -160,7 +161,7 @@ module Spree
           :Street1 => current_order.bill_address.address1,
           :Street2 => current_order.bill_address.address2,
           :CityName => current_order.bill_address.city,
-          # :phone => current_order.bill_address.phone,
+          :Phone => current_order.bill_address.phone,
           :StateOrProvince => current_order.bill_address.state_text,
           :Country => current_order.bill_address.country.iso,
           :PostalCode => current_order.bill_address.zipcode


### PR DESCRIPTION
At present, these customer details are not passed to PayPal, and as a consequence, the user has to re-enter them into PayPal when checking out (particularly when using the 'Sole' solution type). This pull request addresses that by passing those details through.

I've changed the test phone number to all-numeric since PayPal was truncating the non-numeric part. I also had some difficulty testing the phone number field, since it seems that PayPal inconsistently removes the hyphenation from the phone number that we pass to it. I've worked around that here by removing any hyphenation before testing.

Side note: This PR is tested against the 1-3-stable branch. In master, I was unable to test due to an unrelated gem dependency problem that seemed to be related to the release of Spree 2.4.0beta.
