### PR TITLE
Better selector to hide/show the continue button

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/frontend/spree_paypal_express.js
@@ -16,10 +16,10 @@ SpreePaypalExpress = {
     return $('div[data-hook="checkout_payment_step"] input[type="radio"][name="order[payments_attributes][][payment_method_id]"]:checked');
   },
   hideSaveAndContinue: function() {
-    $('.continue').hide();
+    $("#checkout_form_payment [data-hook=buttons]").hide();
   },
   showSaveAndContinue: function() {
-    $('.continue').show();
+    $("#checkout_form_payment [data-hook=buttons]").show();
   }
 }
 


### PR DESCRIPTION
I was having an issue with spree_bootstrap_frontend since they removed the 'continue' class after overriding. I know it's impossible to account for possible overrides, but in general I would put more trust on data-hook elements not being removed from the layout.
