### PR TITLE
Only include additional adjustments so that total matches to get thr...

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -6,10 +6,11 @@ module Spree
       order = current_order || raise(ActiveRecord::RecordNotFound)
       items = order.line_items.map(&method(:line_item))
 
-      tax_adjustments = order.all_adjustments.tax.additional
-      shipping_adjustments = order.all_adjustments.shipping
+      additional_adjustments = order.all_adjustments.additional
+      tax_adjustments = additional_adjustments.tax
+      shipping_adjustments = additional_adjustments.shipping
 
-      order.all_adjustments.eligible.each do |adjustment|
+      additional_adjustments.eligible.each do |adjustment|
         next if (tax_adjustments + shipping_adjustments).include?(adjustment)
         items << {
           :Name => adjustment.label,


### PR DESCRIPTION
...ough PaypalExpress checkout

When a tax rate is inclusive (included in price) the current code still include the adjustments and send it to PaypalExpress API. Paypal will reject the transaction because subtoal + adjustments doesn't match the order total.

The fix in this PR excludes included_adjustments (tax and shipping) so that the total matches.
