### PR TITLE
Automatically re-run failed specs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ Gemfile.lock
 tmp
 pkg
 spec/dummy
+rspec.failures
 .rvmrc
 .idea

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,6 @@ require 'rake'
 require 'rake/testtask'
 require 'rake/packagetask'
 require 'rubygems/package_task'
-require 'rspec/core/rake_task'
-require 'spree/testing_support/extension_rake'
 
 desc 'Generates a dummy app for testing'
 task :test_app do
@@ -14,10 +12,11 @@ end
 
 require 'rspec/core'
 require 'rspec/core/rake_task'
-Rake::Task["spec"].clear
+require 'rspec-rerun'
+require 'spree/testing_support/extension_rake'
+
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.fail_on_error = false
-  t.rspec_opts = %w[-f JUnit -o results.xml]
 end
 
 desc "Run RSpec with code coverage"
@@ -25,7 +24,7 @@ task :coverage do
   ENV['COVERAGE'] = 'true'
   Rake::Task["spec"].execute
 end
-task :default => :spec
+task :default => 'rspec-rerun:spec'
 
 
 Bundler::GemHelper.install_tasks

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl', '~> 4.2'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.14.0'
+  s.add_development_dependency 'rspec-rerun'
   s.add_development_dependency 'sass-rails', '~> 4.0.2'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
This change automatically re-run failed specs. The Paypal gateway has the
bad habit to return server errors at times. The result is a potential false
negative. Re-running the failed spec(s) gives the suite a chance to succeed.
