### PR TITLE
Add flash[:order_completed] to confirm action

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -57,6 +57,7 @@ module Spree
       order.next
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
+        flash['order_completed'] = true
         flash[:commerce_tracking] = "nothing special"
         session[:order_id] = nil
         redirect_to completion_route(order)


### PR DESCRIPTION
Spree has this flash message https://github.com/spree/spree/blob/master/frontend/app/controllers/spree/checkout_controller.rb#L40 so I have added it to keep flashes consistent.