### PR TITLE
Update flash message on completed checkout.

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -57,7 +57,7 @@ module Spree
       order.next
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
-        flash[:commerce_tracking] = "nothing special"
+        flash[:order_completed] = true
         session[:order_id] = nil
         redirect_to completion_route(order)
       else


### PR DESCRIPTION
This was updated beginning in 2-3.  The adjustment fixes the default google analytics ecommerce tracking setup, and thank you message.  This change was updated in this spreecommerce commit https://github.com/spree/spree/commit/a1678bcfe124e44b7658088f52c5717468735137