### PR TITLE
Delete "nothing special" flash message.

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -57,7 +57,6 @@ module Spree
       order.next
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
-        flash[:commerce_tracking] = "nothing special"
         session[:order_id] = nil
         redirect_to completion_route(order)
       else


### PR DESCRIPTION
Customers see "nothing special" on the order confirmation page as a second flash
message below the "Order processed successfully".

I think it is an unwanted effect.