### PR TITLE
Discard all tax adjustments (included + additional) from the list of ite...

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -6,7 +6,7 @@ module Spree
       order = current_order || raise(ActiveRecord::RecordNotFound)
       items = order.line_items.map(&method(:line_item))
 
-      tax_adjustments = order.all_adjustments.tax.additional
+      tax_adjustments = order.all_adjustments.tax
       shipping_adjustments = order.all_adjustments.shipping
 
       order.all_adjustments.eligible.each do |adjustment|


### PR DESCRIPTION
...ms

Before, any tax included adjustment will be added to the list of items
sent to PayPal. Thereby, PayPal will reject the order as the totals of
the line items would not line up with the item total.

Unfortunately, adding a spec for that would be very time-consuming as there are none set-up.
