### PR TITLE
Removed ssl_allowed for Spree v3.x support (Per Spree PR #5827).

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -1,6 +1,5 @@
 module Spree
   class PaypalController < StoreController
-    ssl_allowed
 
     def express
       order = current_order || raise(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
I had opened Issue #149 after upgrading to Spree 3.x. Discussion in the issue revealed that SSL options have were removed from the Spree codebase in PR https://github.com/spree/spree/pull/5827. 

This PR removes the ssl_allowed that is no longer necessary in 3.x and resolves the error message:

> /app/vendor/bundle/ruby/2.1.0/bundler/gems/better_spree_paypal_express-dcdd963524ef/app/controllers/spree/paypal_controller.rb:3:in <class:PaypalController>': undefined local variable or methodssl_allowed' for Spree::PaypalController:Class (NameError)