### PR TITLE
Don't redirect with a token.

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -168,7 +168,7 @@ module Spree
     end
 
     def completion_route(order)
-      order_path(order, :token => order.guest_token)
+      order_path(order)
     end
 
     def address_required?


### PR DESCRIPTION
This exposes the order success page to the world which raises all sorts of privacy concerns.