### PR TITLE
Fix ecommerce tracking

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -56,7 +56,7 @@ module Spree
       order.next
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
-        flash[:commerce_tracking] = "nothing special"
+        flash[:order_completed] = true
         session[:order_id] = nil
         redirect_to completion_route(order)
       else


### PR DESCRIPTION
Spree changed from using the :commerce_tracking flash to use :order_completed quite a while ago. This is currently breaking google analytics ecommerce tracking