### PR TITLE
fix current_symbol_position is no long available in the spree

### DIFF
--- a/app/views/spree/admin/payments/paypal_refund.html.erb
+++ b/app/views/spree/admin/payments/paypal_refund.html.erb
@@ -1,12 +1,9 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
 <% content_for :page_title do %>
-  <i class="icon-arrow-right"></i>
-  <%= link_to Spree.t(:payments), admin_order_payments_path(@order) %>
-  <i class="icon-arrow-right"></i>
-  <%= payment_method_name(@payment) %>
-  <i class="icon-arrow-right"></i>
-  <%= Spree.t('refund', :scope => :paypal) %>
+    / <%= link_to Spree.t(:payments), admin_order_payments_path(@order) %>
+    / <%= payment_method_name(@payment) %>
+    / <%= Spree.t('refund', :scope => :paypal) %>
 <% end %>
 
 <%= form_tag paypal_refund_admin_order_payment_path(@order, @payment) do %>
@@ -14,17 +11,27 @@
     <div>
       <fieldset data-hook="admin_variant_new_form">
         <legend><%= Spree.t('refund', :scope => :paypal) %></legend>
-        <div class='field'>
+        <div class='form-group'>
           <%= label_tag 'refund_amount', Spree.t(:refund_amount, :scope => 'paypal') %>
           <small><em><%= Spree.t(:original_amount, :scope => 'paypal', :amount => @payment.display_amount) %></em></small><br>
-          <% symbol = ::Money.new(1, Spree::Config[:currency]).symbol %>
-          <% if Spree::Config[:currency_symbol_position] == "before" %>
-            <%= symbol %><%= text_field_tag 'refund_amount', @payment.amount %>
-          <% else %>
-            <%= text_field_tag 'refund_amount', @payment.amount %><%= symbol %>
-          <% end %>
         </div>
-        <%= button Spree.t(:refund, scope: 'paypal'), 'money' %>
+
+        <% currency = ::Money::Currency.new(Spree::Config[:currency]) %>
+        <div class="form-group">
+          <div class="input-group">
+            <% if currency.symbol_first %>
+                <span class="input-group-addon" id="basic-addon1"><%= currency.symbol %></span>
+                <%= text_field_tag 'refund_amount', @payment.amount, class: 'form-control' %>
+            <% else %>
+                <%= text_field_tag 'refund_amount', @payment.amount, class: 'form-control' %>
+                <span class="input-group-addon" id="basic-addon1"><%= currency.symbol %></span>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <%= button Spree.t(:refund, scope: 'paypal'), 'money', class: 'btn btn-primary' %>
+        </div>
       </fieldset>
     </div>
   </div>


### PR DESCRIPTION
- using Money::Currency to obtain currency symbol instead of creating
an money object of value 1
- using Money::Currency’s symbol_first property to determine the order
of symbol and value
- change style to use bootstrap since it is default in 3.0