### PR TITLE
Click on the first matching product link

### DIFF
--- a/spec/features/paypal_spec.rb
+++ b/spec/features/paypal_spec.rb
@@ -47,7 +47,7 @@ describe "PayPal", js: true do
 
   def add_to_cart(product)
     visit spree.root_path
-    click_link product.name
+    click_link product.name, match: :first
     click_button 'Add To Cart'
   end
 


### PR DESCRIPTION
Both the image and the text link are matched and clicking on either is
fine, so do it.

This fixes issue #176.