### PR TITLE
Change the dependency for spree_core to 3.2 and bump up SpreePaypalEx…

### DIFF
--- a/lib/spree_paypal_express/version.rb
+++ b/lib/spree_paypal_express/version.rb
@@ -1,3 +1,3 @@
 module SpreePayPalExpress
-  VERSION = '3.0.0'
+  VERSION = '3.2.0'
 end

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0'
+  s.add_dependency 'spree_core', '~> 3.2.0'
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
 
   s.add_development_dependency 'capybara', '~> 2.1'


### PR DESCRIPTION
This gem supports Spree 3.2.0. I have tested out and it is working fine. This pull request bump up the dependency. 