### PR TITLE
Fix feature spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'sqlite3'
 gem 'pg'
 gem 'database_cleaner', '1.0.1'
 
+gem 'rake', '10.1.0'
+
 group :test do
  gem 'yarjuf'
  gem 'require_all'

--- a/Versionfile
+++ b/Versionfile
@@ -1,0 +1,2 @@
+# This file is needed to make `rake test_app` generates propper path for Gemfile
+# See https://github.com/degica/liquidus/blob/master/core/lib/generators/spree/dummy/dummy_generator.rb#L99

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ require 'sass'
 # require 'capybara/poltergeist'
 
 # Capybara.javascript_driver = :poltergeist
-Capybara.default_wait_time = 15
+Capybara.default_max_wait_time = 15
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
This fixes the broken feature spec,  `spec/features/paypal_spec.rb`.

I found this spec fails and [was skipped on other stable branches](https://github.com/spree-contrib/better_spree_paypal_express/commit/e6fa56e1d4be9d178dbe3d563e41c03630dfe98a#diff-77fa29ca89ff4047248fb6b855f7aa4b). I need to customize this gem for our site so I fixed the specs.

Following changes were needed to run it against current PayPal site.

1. `Versionfile` was needed to generate a test app by `rake test_app`
2.  Need to specify version of rake
3.  I Changed many queries for HTML elements to match the current PayPal site
4.  I inserted many `sleep`s for waiting PayPal client side scripts to be ready

Here's difficult or mysterious parts for adjusting test script for PayPal site.

* The new login form is inside of an iframe although there are hidden input fields of email and password outside of it
* Most of event handlers take some seconds after visual elements appear on browser, so I need to insert `sleep` for waiting it
* With geckodriver, cookies are reused so login page of PayPal will be skipped when we run many tests at once.

I think this is used for master or other stable branches but I made a PR for 1-3-stable which I'm using now.
