### PR TITLE
Fixes test suite by adding puma as development dependency in gemspec

### DIFF
--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'require_all'
   s.add_development_dependency 'pg', '~> 0.18'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Not sure if anyone else can replicate but when running the tests I see the following error:

```
Failure/Error: raise LoadError, "Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`."
```

Tested with ruby `2.5.1` & `2.3.1` (latest version tested on `travis.yml`) and adding puma fixed it.

I'm aware the repo hasn't seen much activity in a while and I want to tackle some other things, so this comes first I guess.