### PR TITLE
Fix expired SSL certificate Error from using the old PayPal SDK.

### DIFF
--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -19,10 +19,12 @@ module Spree
 
     def provider
       ::PayPal::SDK.configure(
-        :mode      => preferred_server.present? ? preferred_server : "sandbox",
-        :username  => preferred_login,
-        :password  => preferred_password,
-        :signature => preferred_signature)
+        :mode        => preferred_server.present? ? preferred_server : "sandbox",
+        :username    => preferred_login,
+        :password    => preferred_password,
+        :signature   => preferred_signature,
+        :ssl_options => { :ca_file => nil }
+      )
       provider_class.new
     end
 


### PR DESCRIPTION
from https://github.com/spree-contrib/better_spree_paypal_express/pull/214/commits/8614a3556830ac58fddb949848c4be3b009adc59

I need to update the 3-0 branch and I preserved the old sintax