### PR TITLE
Fix JS errors

### DIFF
--- a/app/assets/javascripts/spree/backend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/backend/spree_paypal_express.js
@@ -16,7 +16,7 @@ SpreePaypalExpress = {
   }
 }
 
-$(document).ready(function() {
+Spree.ready(function() {
   checkedPaymentMethod = $('[data-hook="payment_method_field"] input[type="radio"]:checked');
   SpreePaypalExpress.hideSettings(checkedPaymentMethod);
   paymentMethods = $('[data-hook="payment_method_field"] input[type="radio"]').click(function (e) {

--- a/app/assets/javascripts/spree/frontend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/frontend/spree_paypal_express.js
@@ -17,9 +17,13 @@ SpreePaypalExpress = {
   },
   hideSaveAndContinue: function() {
     $("#checkout_form_payment [data-hook=buttons]").hide();
+    $("#checkout_form_payment").data('hidden-by-payment-method-id', SpreePaypalExpress.paymentMethodID);
   },
   showSaveAndContinue: function() {
-    $("#checkout_form_payment [data-hook=buttons]").show();
+    if (typeof ($("#checkout_form_payment").data('hidden-by-payment-method-id')) === 'undefined' || $("#checkout_form_payment").data('hidden-by-payment-method-id') == SpreePaypalExpress.paymentMethodID) {
+      $("#checkout_form_payment [data-hook=buttons]").show();
+      $("#checkout_form_payment").removeData('hidden-by-payment-method-id');
+    }
   }
 }
 

--- a/app/assets/javascripts/spree/frontend/spree_paypal_express.js
+++ b/app/assets/javascripts/spree/frontend/spree_paypal_express.js
@@ -23,7 +23,8 @@ SpreePaypalExpress = {
   }
 }
 
-$(document).ready(function() {
+Spree.ready(function() {
+  SpreePaypalExpress.paymentMethodID = $('#paypal_button').data('payment-method-id');
   SpreePaypalExpress.updateSaveAndContinueVisibility();
   paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
     SpreePaypalExpress.updateSaveAndContinueVisibility();

--- a/app/views/spree/checkout/payment/_paypal.html.erb
+++ b/app/views/spree/checkout/payment/_paypal.html.erb
@@ -1,6 +1,2 @@
 
-<%= link_to(image_tag("https://www.paypal.com/en_US/i/btn/btn_xpressCheckout.gif"), paypal_express_url(:payment_method_id => payment_method.id), :method => :post, :id => "paypal_button") %>
-
-<script>
-  SpreePaypalExpress.paymentMethodID = "<%= payment_method.id %>"  
- </script>
+<%= link_to(image_tag("https://www.paypal.com/en_US/i/btn/btn_xpressCheckout.gif"), paypal_express_url(:payment_method_id => payment_method.id), :method => :post, :id => "paypal_button", data: { 'payment-method-id' => payment_method.id }) %>


### PR DESCRIPTION
The way the paymentMethodID is passed to the JS is not working due to scripts not being loaded yet.
Fixed this by passing it through a data attribute on the button. I also used Spree.ready instead of $(document).ready.

Also I added a way to track which lib hid the save button, because I based another payment system on this gem and they would then override hiding the button between each other (basically one lib would hide the button but the other one would show it back immediately). Although it's not needed for this gem itself it may be helpful to others in similar situation or if I release the other gem.

By the way really thanks for this gem, I can't believe how amateur and shitty the official spree braintree vzero gem is. Looks like they used it as a play project for their juniors to try Ruby or something. Meanwhile this gem hasn't had an update for 3 years and still works great except for this JS error and the SSL issue, but these are not hard to fix.